### PR TITLE
Refactor KNNMethodContext with Lombok

### DIFF
--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
@@ -5,10 +5,6 @@
 
 package org.opensearch.knn.index.engine;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -37,25 +33,70 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  * KNNMethodContext will contain the information necessary to produce a library index from an Opensearch mapping.
  * It will encompass all parameters necessary to build the index.
  */
-@AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter
-@Builder
 public class KNNMethodContext implements ToXContentFragment, Writeable {
 
     @NonNull
-    @Default
     private KNNEngine knnEngine = KNNEngine.DEFAULT;
     @NonNull
     @Setter
-    @Default
     private SpaceType spaceType = SpaceType.UNDEFINED;
     @NonNull
     private final MethodComponentContext methodComponentContext;
     // Currently, the KNNEngine member variable cannot be null and defaults during parsing to nmslib. However, in order
     // to support disk based engine resolution, this value potentially needs to be updated. Thus, this value is used
     // to determine if the variable can be overridden or not based on whether the user explicitly set the value during parsing
-    @Default
     private boolean isEngineConfigured = false;
+
+    private KNNMethodContext(
+        KNNEngine knnEngine,
+        SpaceType spaceType,
+        MethodComponentContext methodComponentContext,
+        boolean isEngineConfigured
+    ) {
+        this.knnEngine = knnEngine;
+        this.spaceType = spaceType;
+        this.methodComponentContext = methodComponentContext;
+        this.isEngineConfigured = isEngineConfigured;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private KNNEngine knnEngine = KNNEngine.DEFAULT;
+        private SpaceType spaceType = SpaceType.UNDEFINED;
+        private MethodComponentContext methodComponentContext;
+        private boolean isEngineConfigured = false;
+
+        private Builder() {}
+
+        public Builder knnEngine(KNNEngine knnEngine) {
+            this.knnEngine = knnEngine;
+            this.isEngineConfigured = true;
+            return this;
+        }
+
+        public Builder spaceType(SpaceType spaceType) {
+            this.spaceType = spaceType;
+            return this;
+        }
+
+        public Builder methodComponentContext(MethodComponentContext methodComponentContext) {
+            this.methodComponentContext = methodComponentContext;
+            return this;
+        }
+
+        public Builder isEngineConfigured(boolean isEngineConfigured) {
+            this.isEngineConfigured = isEngineConfigured;
+            return this;
+        }
+
+        public KNNMethodContext build() {
+            return new KNNMethodContext(knnEngine, spaceType, methodComponentContext, isEngineConfigured);
+        }
+    }
 
 
 
@@ -271,20 +312,5 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         out.writeString(spaceType.getValue());
         this.methodComponentContext.writeTo(out);
     }
-
-    /**
-     * Custom builder to ensure {@code isEngineConfigured} is set when {@code knnEngine}
-     * is explicitly provided.
-     */
-    public static class KNNMethodContextBuilder {
-        private boolean isEngineConfigured = false;
-
-        public KNNMethodContextBuilder knnEngine(KNNEngine knnEngine) {
-            this.knnEngine = knnEngine;
-            this.isEngineConfigured = true;
-            return this;
-        }
-    }
-
 
 }

--- a/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
+++ b/src/main/java/org/opensearch/knn/index/engine/KNNMethodContext.java
@@ -7,6 +7,8 @@ package org.opensearch.knn.index.engine;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -37,19 +39,25 @@ import static org.opensearch.knn.common.KNNConstants.PARAMETERS;
  */
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter
+@Builder
 public class KNNMethodContext implements ToXContentFragment, Writeable {
 
     @NonNull
-    private KNNEngine knnEngine;
+    @Default
+    private KNNEngine knnEngine = KNNEngine.DEFAULT;
     @NonNull
     @Setter
-    private SpaceType spaceType;
+    @Default
+    private SpaceType spaceType = SpaceType.UNDEFINED;
     @NonNull
     private final MethodComponentContext methodComponentContext;
     // Currently, the KNNEngine member variable cannot be null and defaults during parsing to nmslib. However, in order
     // to support disk based engine resolution, this value potentially needs to be updated. Thus, this value is used
     // to determine if the variable can be overridden or not based on whether the user explicitly set the value during parsing
-    private boolean isEngineConfigured;
+    @Default
+    private boolean isEngineConfigured = false;
+
+
 
     /**
      * Copy constructor. Useful for creating a deep copy of a {@link KNNMethodContext}. Note that the engine and
@@ -222,7 +230,12 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
 
         MethodComponentContext method = new MethodComponentContext(name, parameters);
 
-        return new KNNMethodContext(engine, spaceType, method, isEngineConfigured);
+        return KNNMethodContext.builder()
+            .knnEngine(engine)
+            .spaceType(spaceType)
+            .methodComponentContext(method)
+            .isEngineConfigured(isEngineConfigured)
+            .build();
     }
 
     @Override
@@ -258,4 +271,20 @@ public class KNNMethodContext implements ToXContentFragment, Writeable {
         out.writeString(spaceType.getValue());
         this.methodComponentContext.writeTo(out);
     }
+
+    /**
+     * Custom builder to ensure {@code isEngineConfigured} is set when {@code knnEngine}
+     * is explicitly provided.
+     */
+    public static class KNNMethodContextBuilder {
+        private boolean isEngineConfigured = false;
+
+        public KNNMethodContextBuilder knnEngine(KNNEngine knnEngine) {
+            this.knnEngine = knnEngine;
+            this.isEngineConfigured = true;
+            return this;
+        }
+    }
+
+
 }

--- a/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
+++ b/src/test/java/org/opensearch/knn/index/engine/KNNMethodContextTests.java
@@ -363,6 +363,29 @@ public class KNNMethodContextTests extends KNNTestCase {
         assertTrue(deserialized.getParameters().isEmpty());
     }
 
+    public void testBuilderDefaults() {
+        MethodComponentContext component = new MethodComponentContext("test", Collections.emptyMap());
+        KNNMethodContext context = KNNMethodContext.builder().methodComponentContext(component).build();
+
+        assertEquals(KNNEngine.DEFAULT, context.getKnnEngine());
+        assertEquals(SpaceType.UNDEFINED, context.getSpaceType());
+        assertFalse(context.isEngineConfigured());
+        assertEquals(component, context.getMethodComponentContext());
+    }
+
+    public void testBuilderKnnEngineSetsFlag() {
+        MethodComponentContext component = new MethodComponentContext("test", Collections.emptyMap());
+        KNNMethodContext context = KNNMethodContext.builder()
+            .knnEngine(KNNEngine.FAISS)
+            .spaceType(SpaceType.L2)
+            .methodComponentContext(component)
+            .build();
+
+        assertTrue(context.isEngineConfigured());
+        assertEquals(KNNEngine.FAISS, context.getKnnEngine());
+        assertEquals(SpaceType.L2, context.getSpaceType());
+    }
+
     private void validateValidateVectorDataType(
         final KNNEngine knnEngine,
         final String methodName,


### PR DESCRIPTION
## Summary
- use Lombok's `@Builder` for `KNNMethodContext`
- adjust parsing logic to use generated builder
- add custom builder class to set `isEngineConfigured`
- add unit tests for builder defaults and engine flag

## Testing
- `./gradlew help` *(fails: Could not resolve build-tools)*
- `./gradlew test` *(fails: Could not resolve build-tools)*
- `./gradlew spotlessCheck` *(fails: Could not resolve build-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68499704c5148328bac9520abfb700b4