### PR TITLE
Generalize feature IT harness and add recall checks

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -438,6 +438,7 @@ with `@ExpectRemoteBuildValidation`, for the `@After` method `verifyRemoteIndexB
 - OpenSearchIT
 - SegmentReplicationIT
 - DerivedSourceIT
+- FeatureTestCase (base for new feature tests)
 - ExpandNestedDocsIT
 - FilteredSearchANNSearchIT
 - IndexIT

--- a/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
+++ b/src/test/java/org/opensearch/knn/integ/DerivedSourceIT.java
@@ -164,6 +164,7 @@ public class DerivedSourceIT extends DerivedSourceTestCase {
 
         // Search
         testSearch(indexConfigContexts);
+        validateVectorRecall(indexConfigContexts);
 
         // Reindex
         testReindex(indexConfigContexts);

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceTestCase.java
@@ -15,13 +15,17 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.knn.index.VectorDataType;
+import org.opensearch.knn.IDVectorProducer;
+import org.opensearch.knn.TestUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public class DerivedSourceTestCase extends KNNRestTestCase {
@@ -923,6 +927,28 @@ public class DerivedSourceTestCase extends KNNRestTestCase {
         Map<String, Object> response1 = getKnnDoc(index1, String.valueOf(docId));
         Map<String, Object> response2 = getKnnDoc(index2, String.valueOf(docId));
         assertEquals("Docs do not match: " + docId, response1, response2);
+    }
+
+    @SneakyThrows
+    protected void validateVectorRecall(List<DerivedSourceUtils.IndexConfigContext> indexConfigContexts) {
+        DerivedSourceUtils.IndexConfigContext enabled = indexConfigContexts.get(0);
+
+        for (DerivedSourceUtils.KNNVectorFieldTypeContext vectorField : enabled.collectVectorFields()) {
+            int dimension = vectorField.dimension;
+            int queryCount = Math.min(5, enabled.docCount);
+            IDVectorProducer producer = new IDVectorProducer(dimension, enabled.docCount + queryCount);
+            float[][] queryVectors = new float[queryCount][dimension];
+            for (int i = 0; i < queryCount; i++) {
+                queryVectors[i] = producer.getVector(enabled.docCount + i);
+            }
+
+            int k = Math.min(3, enabled.docCount);
+            List<List<String>> groundResults = bulkExactSearch(enabled.indexName, vectorField.fieldPath, queryVectors, k);
+            List<List<String>> testResults = bulkSearch(enabled.indexName, vectorField.fieldPath, queryVectors, k);
+            List<Set<String>> groundTruth = groundResults.stream().map(HashSet::new).toList();
+            double recall = TestUtils.calculateRecallValue(testResults, groundTruth, k);
+            assertTrue("Low recall for " + vectorField.fieldPath + ":" + recall, recall >= 0.8d);
+        }
     }
 
     protected String getIndexName(String testPrefix, String indexPrefix, boolean addRandom) {

--- a/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
+++ b/src/testFixtures/java/org/opensearch/knn/DerivedSourceUtils.java
@@ -163,6 +163,24 @@ public class DerivedSourceUtils {
         public List<String> collectFieldNames() {
             return fields.stream().map(f -> f.fieldPath).toList();
         }
+
+        @SneakyThrows
+        public List<KNNVectorFieldTypeContext> collectVectorFields() {
+            List<KNNVectorFieldTypeContext> vectors = new ArrayList<>();
+            collectVectorFields(fields, vectors);
+            return vectors;
+        }
+
+        private void collectVectorFields(List<FieldContext> fieldContexts, List<KNNVectorFieldTypeContext> vectors)
+            throws IOException {
+            for (FieldContext context : fieldContexts) {
+                if (context instanceof KNNVectorFieldTypeContext) {
+                    vectors.add((KNNVectorFieldTypeContext) context);
+                } else if (context instanceof CompositeFieldContext) {
+                    collectVectorFields(((CompositeFieldContext) context).children, vectors);
+                }
+            }
+        }
     }
 
     @SuperBuilder

--- a/src/testFixtures/java/org/opensearch/knn/FeatureTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/FeatureTestCase.java
@@ -1,0 +1,10 @@
+package org.opensearch.knn;
+
+/**
+ * Generic test case that exposes the utilities in {@link DerivedSourceTestCase} for
+ * features beyond derived source. Extend this class when adding integration tests
+ * for new features that require comprehensive index operations.
+ */
+public abstract class FeatureTestCase extends DerivedSourceTestCase {
+    // Intentionally empty. Inherit functionality from DerivedSourceTestCase.
+}

--- a/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
+++ b/src/testFixtures/java/org/opensearch/knn/KNNRestTestCase.java
@@ -1856,6 +1856,28 @@ public class KNNRestTestCase extends ODFERestTestCase {
         return searchResults;
     }
 
+    // Method that performs exact vector search using script scoring for multiple queries
+    public List<List<String>> bulkExactSearch(String indexName, String fieldName, float[][] queryVectors, int k)
+        throws Exception {
+        List<List<String>> searchResults = new ArrayList<>();
+        for (float[] queryVector : queryVectors) {
+            QueryBuilder qb = new MatchAllQueryBuilder();
+            Map<String, Object> params = new HashMap<>();
+            params.put(TestUtils.FIELD, fieldName);
+            params.put(TestUtils.QUERY_VALUE, queryVector);
+            params.put(METHOD_PARAMETER_SPACE_TYPE, SpaceType.L2.getValue());
+
+            Request request = constructKNNScriptQueryRequest(indexName, qb, params, k, Collections.emptyMap());
+            Response resp = client().performRequest(request);
+            assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(resp.getStatusLine().getStatusCode()));
+
+            List<KNNResult> results = parseSearchResponse(EntityUtils.toString(resp.getEntity()), fieldName);
+            assertEquals(k, results.size());
+            searchResults.add(results.stream().map(KNNResult::getDocId).toList());
+        }
+        return searchResults;
+    }
+
     // Method that waits till the health of nodes in the cluster goes green
     public void waitForClusterHealthGreen(String numOfNodes) throws IOException {
         Request waitForGreen = new Request("GET", "/_cluster/health");


### PR DESCRIPTION
## Summary
- add FeatureTestCase for reusing DerivedSource utilities
- collect vector fields in DerivedSourceUtils
- validate recall for vector search with exact search baseline
- document FeatureTestCase

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve build-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68499e2362bc8328bda482b3b90d27ea